### PR TITLE
Update Dockerfile to use python:3.6-buster and fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.6-stretch
+FROM python:3.6-buster 
 
 RUN pip install numpy==1.16.6
 RUN pip install flask==1.1.1
 RUN pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 RUN pip install librosa==0.7.2
 RUN pip install python-speech-features==0.6
+RUN pip install numba==0.48.0
+RUN pip install resampy==0.2.2
 
-RUN apt-get update -y
-RUN apt-get install -y libsndfile1
+# Update repositories and install libsndfile1
+RUN apt-get update -y && \
+    apt-get install -y libsndfile1
 
 COPY fbank_net/demo /fbank_net/demo
 COPY fbank_net/model_training /fbank_net/model_training


### PR DESCRIPTION
- Change base image from `python:3.6-stretch` to `python:3.6-buster` to avoid outdated package repositories causing build failures.
- Add installation of `numba==0.48.0` and `resampy==0.2.2` to resolve ImportError and TypeError issues related to `librosa` and `resampy`.
- Ensure compatibility with updated dependencies and improve build reliability.

These changes address the following issues encountered during the Docker build process:
- The `python:3.6-stretch` image references outdated Debian Stretch repositories, causing apt-get update failures.
- Missing `numba.decorators` module required by `librosa`.
- `TypeError: guvectorize() missing 1 required positional argument: 'signature'` caused by an incompatible `resampy` version.

By switching to `python:3.6-buster` and explicitly installing `numba` and `resampy`, Docker image builds successfully and the application runs without import errors.